### PR TITLE
feat: update plan pricing and promotions

### DIFF
--- a/index.html
+++ b/index.html
@@ -768,6 +768,7 @@
         <section class="section" id="plans">
             <div class="container">
                 <h2>Subscription Plans - Better Value, Better Results</h2>
+                <p style="text-align: center; font-size: 1.125rem; color: var(--warm-gray); margin-bottom: 1rem;"><strong>$10 first-time walk</strong> &middot; First week free for new customers who purchase a month.</p>
                 <p style="text-align: center; font-size: 1.125rem; color: var(--warm-gray); margin-bottom: 3rem;">Consistent exercise leads to happier, healthier dogs. Our subscription plans offer priority scheduling, GPS updates, and monthly rollovers.</p>
                 
                 <div class="image-placeholder" style="max-width: 600px; margin: 2rem auto; min-height: 200px;">
@@ -780,8 +781,8 @@
                 <div class="grid-2">
                     <div class="plan-card card">
                         <h3>Balanced Routine</h3>
-                        <div class="price">$105<span style="font-size: 1rem; font-weight: normal;">/month</span></div>
-                        <div class="savings">Save $15/month vs a la carte</div>
+                        <div class="price">$26<span style="font-size: 1rem; font-weight: normal;">/week</span></div>
+                        <div class="savings">Save $4/week vs a la carte</div>
                         <ul class="feature-list">
                             <li>3 × 30-minute walks per week</li>
                             <li>~6 hours of exercise monthly</li>
@@ -789,14 +790,14 @@
                             <li>GPS photo updates</li>
                             <li>2 monthly rollovers</li>
                         </ul>
-                        <p><em>Regular pricing: $120/month a la carte</em></p>
+                        <p><em>Regular pricing: $30/week a la carte</em></p>
                         <a href="#book" class="btn btn-secondary" style="margin-top: 1rem; width: 100%;">Choose Balanced</a>
                     </div>
 
                     <div class="plan-card card featured">
                         <h3>Everyday Energy</h3>
-                        <div class="price">$175<span style="font-size: 1rem; font-weight: normal;">/month</span></div>
-                        <div class="savings">Save $25/month vs a la carte</div>
+                        <div class="price">$44<span style="font-size: 1rem; font-weight: normal;">/week</span></div>
+                        <div class="savings">Save $6/week vs a la carte</div>
                         <ul class="feature-list">
                             <li>5 × 30-minute walks per week</li>
                             <li>~10 hours of exercise monthly</li>
@@ -805,10 +806,11 @@
                             <li>2 monthly rollovers</li>
                             <li><strong>Best for high-energy dogs</strong></li>
                         </ul>
-                        <p><em>Regular pricing: $200/month a la carte</em></p>
-                        <a href="#book" class="btn btn-primary" style="margin-top: 1rem; width: 100%;">Choose Everyday</a>
+                        <p><em>Regular pricing: $50/week a la carte</em></p>
+                    <a href="#book" class="btn btn-primary" style="margin-top: 1rem; width: 100%;">Choose Everyday</a>
                     </div>
                 </div>
+                <p style="text-align: center; font-size: 0.875rem; color: var(--warm-gray); margin-top: 1rem;">Plans billed monthly.</p>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- show plan pricing per week instead of per month
- add promotional messaging for first-time and new customers
- note that plans are billed monthly

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894a9b4e8f48323b19687984b7decd4