### PR TITLE
feat: update Everyday Energy plan for hourly walks

### DIFF
--- a/index.html
+++ b/index.html
@@ -824,17 +824,17 @@
 
                     <div class="plan-card card featured">
                         <h3>Everyday Energy</h3>
-                        <div class="price">$44<span style="font-size: 1rem; font-weight: normal;">/week</span></div>
-                        <div class="savings">Save $6/week vs a la carte</div>
+                        <div class="price">$120<span style="font-size: 1rem; font-weight: normal;">/week</span></div>
+                        <div class="savings">Save $15/week vs a la carte</div>
                         <ul class="feature-list">
-                            <li>5 × 30-minute walks per week</li>
-                            <li>~10 hours of exercise monthly</li>
+                            <li>5 × 1-hour walks per week</li>
+                            <li>~20 hours of exercise monthly</li>
                             <li>Priority scheduling</li>
                             <li>GPS photo updates</li>
                             <li>2 monthly rollovers</li>
                             <li><strong>Best for high-energy dogs</strong></li>
                         </ul>
-                        <p><em>Regular pricing: $50/week a la carte</em></p>
+                        <p><em>Regular pricing: $135/week a la carte</em></p>
                     <a href="#book" class="btn btn-primary" style="margin-top: 1rem; width: 100%;">Choose Everyday</a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- adjust Everyday Energy plan to five 1-hour walks weekly (~20 hours/month)
- set price to $120/week with $15 savings vs $135 a-la-carte baseline
- keep plan highlighted as featured

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b5c283388323b679b0cf9cacc1eb