### PR TITLE
Refresh palette and CTA styling for AmesDogWalking

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@
         }
 
         :root {
-            --primary-green: #4a7c59;
-            --light-green: #6b9c7a;
-            --forest-green: #2e5933;
-            --sky-blue: #64b5f6;
-            --warm-beige: #f5f1eb;
-            --soft-orange: #ffa726;
+            --primary-green: #2a9d8f;
+            --light-green: #84dcc6;
+            --forest-green: #264653;
+            --sky-blue: #a8dadc;
+            --warm-beige: #f1faee;
+            --soft-orange: #e9c46a;
             --warm-gray: #6b6860;
-            --dark-gray: #2d2d2d;
+            --dark-gray: #1d3557;
             --white: #ffffff;
             --shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
             --shadow-hover: 0 8px 30px rgba(0, 0, 0, 0.15);
@@ -105,7 +105,7 @@
         .logo-placeholder {
             width: 40px;
             height: 40px;
-            background: linear-gradient(135deg, var(--primary-green), var(--light-green));
+            background: linear-gradient(135deg, var(--primary-green), var(--soft-orange));
             border-radius: 50%;
             display: flex;
             align-items: center;
@@ -165,8 +165,9 @@
 
         .btn-primary:hover,
         .btn-primary:focus {
-            background: var(--light-green);
-            border-color: var(--light-green);
+            background: var(--soft-orange);
+            border-color: var(--soft-orange);
+            color: var(--dark-gray);
             outline: 2px solid var(--primary-green);
             outline-offset: 2px;
             transform: translateY(-2px);
@@ -181,7 +182,9 @@
 
         .btn-secondary:hover,
         .btn-secondary:focus {
-            background: var(--sky-blue);
+            background: var(--soft-orange);
+            color: var(--dark-gray);
+            border-color: var(--soft-orange);
             outline: 2px solid var(--primary-green);
             outline-offset: 2px;
             transform: translateY(-2px);
@@ -214,7 +217,7 @@
         /* Hero section */
         .hero {
             padding: 6rem 0;
-            background: linear-gradient(135deg, var(--sky-blue) 0%, var(--warm-beige) 50%, #fff8f0 100%);
+            background: linear-gradient(135deg, var(--sky-blue) 0%, var(--warm-beige) 60%, var(--soft-orange) 100%);
             position: relative;
             overflow: hidden;
         }
@@ -226,7 +229,7 @@
             right: -20%;
             width: 100%;
             height: 200%;
-            background: radial-gradient(circle, rgba(74, 124, 89, 0.05) 0%, transparent 70%);
+            background: radial-gradient(circle, rgba(42, 157, 143, 0.05) 0%, transparent 70%);
             transform: rotate(15deg);
         }
 
@@ -503,7 +506,7 @@
 
         /* Footer styles */
         .footer {
-            background: linear-gradient(135deg, var(--dark-gray) 0%, #1a1a1a 100%);
+            background: linear-gradient(135deg, var(--forest-green) 0%, var(--dark-gray) 100%);
             color: var(--white);
             text-align: center;
             padding: 2rem 0;


### PR DESCRIPTION
## Summary
- Adopt a cohesive teal and amber palette by redefining CSS variables and gradients for hero and footer.
- Enhance primary and secondary buttons to highlight the new accent color on hover for better calls to action.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b933a278832382a5a740a836e7ee