### PR TITLE
Align pricing details with updated rates

### DIFF
--- a/index.html
+++ b/index.html
@@ -785,8 +785,8 @@
                 <div class="card" style="text-align: center; max-width: 400px; margin: 2rem auto;">
                     <div class="promo-banner" style="margin-bottom: 1rem;">Special Trial Offer: First walk only $10 for 30 minutes!</div>
                     <h3>A La Carte Walking</h3>
-                    <div class="price">$27<span style="font-size: 1rem; font-weight: normal;">/hour per dog</span></div>
-                    <p><strong>Example:</strong> 30-minute visit = $13.50</p>
+                    <div class="price">$25<span style="font-size: 1rem; font-weight: normal;">/hour per dog</span></div>
+                    <p><strong>Example:</strong> 30-minute visit = $12.50</p>
                     <p>Perfect for occasional walks or trying out the service. Book individual visits as needed.</p>
                     <div class="cta-buttons" style="justify-content: center;">
                         <a href="#book" class="btn btn-primary">Claim Your $10 First Walk</a>
@@ -813,7 +813,7 @@
                     <div class="plan-card card">
                         <h3>Balanced Routine</h3>
                           <div class="price">$38<span style="font-size: 1rem; font-weight: normal;">/week</span></div>
-                          <div class="savings">Save $8/week vs a la carte</div>
+                            <div class="savings">Save $37/week vs a la carte</div>
                         <ul class="feature-list">
                               <li>3 × 1-hour walks per week</li>
                               <li>~12 hours of exercise monthly</li>
@@ -821,14 +821,14 @@
                             <li>GPS photo updates</li>
                             <li>2 monthly rollovers</li>
                         </ul>
-                          <p><em>Regular pricing: $81/week a la carte</em></p>
+                            <p><em>Regular pricing: $75/week a la carte</em></p>
                         <a href="#book" class="btn btn-secondary" style="margin-top: 1rem; width: 100%;">Choose Balanced</a>
                     </div>
 
                     <div class="plan-card card featured">
                         <h3>Everyday Energy</h3>
                         <div class="price">$50<span style="font-size: 1rem; font-weight: normal;">/week</span></div>
-                        <div class="savings">Save $15/week vs a la carte</div>
+                          <div class="savings">Save $75/week vs a la carte</div>
                         <ul class="feature-list">
                             <li>5 × 1-hour walks per week</li>
                             <li>~20 hours of exercise monthly</li>
@@ -837,7 +837,7 @@
                             <li>2 monthly rollovers</li>
                             <li><strong>Best for high-energy dogs</strong></li>
                         </ul>
-                        <p><em>Regular pricing: $135/week a la carte</em></p>
+                          <p><em>Regular pricing: $125/week a la carte</em></p>
                     <a href="#book" class="btn btn-primary" style="margin-top: 1rem; width: 100%;">Choose Everyday</a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Update a la carte walking rate to $25/hour and adjust 30-minute example
- Recalculate savings and regular pricing for Balanced Routine and Everyday Energy plans

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894ce15091c83238b91b93b0d1b3b52