### PR TITLE
Keep paired images aligned horizontally

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,11 +264,12 @@
             display: flex;
             justify-content: center;
             gap: 1rem;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             align-items: center;
         }
 
         .image-pair img {
+            flex: 1 1 50%;
             max-width: 100%;
             height: auto;
         }


### PR DESCRIPTION
## Summary
- prevent `.image-pair` containers from wrapping so images stay in a row
- let `.image-pair img` flex evenly to share the container width
- verified that all sequential images are wrapped in `.image-pair` containers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898bf1a9c9c8323a460db7c9332b34f