### PR TITLE
Add promo card and styles for plans section

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,12 +753,22 @@
         </section>
 
         <!-- Plans (Subscriptions) -->
-        <section class="section" id="plans">
+        <section id="plans" class="section section-plans">
             <div class="container">
                 <h2>Subscription Plans - Better Value, Better Results</h2>
                 <p style="text-align: center; font-size: 1.125rem; color: var(--warm-gray); margin-bottom: 1rem;"><strong>$10 first-time walk</strong> &middot; First week free for new customers who purchase a month.</p>
                 <p style="text-align: center; font-size: 1.125rem; color: var(--warm-gray); margin-bottom: 3rem;">Consistent exercise leads to happier, healthier dogs. Our subscription plans offer priority scheduling, GPS updates, and monthly rollovers.</p>
-                
+
+                <div class="offer-card">
+                    <div class="chips">
+                        <span class="chip">Intro Offer</span>
+                        <span class="chip chip-orange">Limited Time</span>
+                    </div>
+                    <h3>Founder's Discount</h3>
+                    <p>Lock in our best rate ever — first week free and $10 first-time walk.</p>
+                    <a href="#book" class="btn btn-primary offer-cta">Claim Your Spot</a>
+                </div>
+
                 <div class="image-pair" style="max-width: 600px; margin: 2rem auto;">
                     <img src="images/funny2.jpg" class="responsive-image" alt="Playful dog enjoying a walk">
                     <img src="images/funny1.jpg" class="responsive-image" alt="Goofy dog smiling about walk time">

--- a/modern-additions.css
+++ b/modern-additions.css
@@ -163,7 +163,70 @@ h3 { font-weight: 600; }
 @keyframes sheen{ to{ transform:translateX(120%);} }
 
 /* Focus visibility */
-.nav a:focus-visible,.btn.btn-primary:focus-visible{
+  .nav a:focus-visible,.btn.btn-primary:focus-visible{
   box-shadow:0 0 0 3px rgba(61,218,180,.45);
   border-radius:12px;
+}
+
+/* Plans hero background */
+.section-plans {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(180deg, var(--warm-beige), var(--white));
+}
+.section-plans::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 0%, var(--soft-orange) 0%, transparent 70%);
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+/* Promo card */
+.offer-card {
+  max-width: 600px;
+  margin: 0 auto 3rem;
+  padding: 2rem;
+  background: var(--white);
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-soft);
+  text-align: center;
+}
+
+/* Chips */
+.offer-card .chips {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.offer-card .chip {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--sky-blue);
+  color: var(--dark-gray);
+  font-weight: 600;
+  font-size: 0.875rem;
+  box-shadow: none;
+  border: none;
+}
+.offer-card .chip-orange {
+  background: var(--soft-orange);
+}
+
+/* CTA */
+.offer-card .offer-cta {
+  margin-top: 1.5rem;
+  display: inline-block;
+}
+
+/* Responsive tweaks */
+@media (max-width: 640px) {
+  .offer-card {
+    padding: 1.5rem;
+  }
+  .offer-card .chip {
+    font-size: 0.75rem;
+  }
 }


### PR DESCRIPTION
## Summary
- style plans section with gradient background and responsive promo card
- insert promotional offer card with chips and CTA in Plans area

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3d95a4348323ab16bd23e7fd1e4c