### PR TITLE
Style How I Work section with sticky timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,33 +518,6 @@
             margin: 1rem 0;
         }
 
-        .process-step {
-            position: relative;
-            padding-left: 3rem;
-        }
-
-        .process-step::before {
-            content: counter(step-counter);
-            counter-increment: step-counter;
-            position: absolute;
-            left: 0;
-            top: 0;
-            width: 2rem;
-            height: 2rem;
-            background: linear-gradient(135deg, var(--primary-green), var(--light-green));
-            color: var(--white);
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: bold;
-            font-size: 0.875rem;
-        }
-
-        .process-steps {
-            counter-reset: step-counter;
-        }
-
         /* Mobile responsive */
         @media (max-width: 768px) {
             .nav {
@@ -705,7 +678,7 @@
         </section>
 
         <!-- How I Work -->
-        <section class="section">
+        <section class="section section-how" id="how-i-work">
             <div class="container">
                 <h2>How I Work</h2>
                 <img src="images/process.png" class="responsive-image" style="max-width: 500px; margin: 2rem auto;" alt="Professional dog walker following safety checklist with GPS tracking and water for dog">

--- a/index.html
+++ b/index.html
@@ -518,6 +518,33 @@
             margin: 1rem 0;
         }
 
+        .process-step {
+            position: relative;
+            padding-left: 3rem;
+        }
+
+        .process-step::before {
+            content: counter(step-counter);
+            counter-increment: step-counter;
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 2rem;
+            height: 2rem;
+            background: linear-gradient(135deg, var(--primary-green), var(--light-green));
+            color: var(--white);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            font-size: 0.875rem;
+        }
+
+        .process-steps {
+            counter-reset: step-counter;
+        }
+
         /* Mobile responsive */
         @media (max-width: 768px) {
             .nav {

--- a/modern-additions.css
+++ b/modern-additions.css
@@ -167,3 +167,68 @@ h3 { font-weight: 600; }
   box-shadow:0 0 0 3px rgba(61,218,180,.45);
   border-radius:12px;
 }
+
+/* How I Work sticky photo and timeline */
+.section-how .container {
+  display: grid;
+  gap: 2rem;
+}
+
+.section-how .process-steps {
+  counter-reset: step;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.section-how .process-step {
+  position: relative;
+  padding-left: 3rem;
+}
+
+.section-how .process-step::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--primary-green);
+  color: var(--white);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.section-how .process-step::after {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  top: 2rem;
+  width: 2px;
+  height: calc(100% - 2rem);
+  background: var(--primary-green);
+}
+
+.section-how .process-step:last-child::after {
+  display: none;
+}
+
+.section-how img {
+  width: 100%;
+  height: auto;
+}
+
+@media (min-width: 768px) {
+  .section-how .container {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+  .section-how img {
+    position: sticky;
+    top: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `section-how` identifier and anchor to the How I Work section
- Introduce sticky photo and step counter timeline styles for the How I Work content
- Remove redundant inline timeline styles from `index.html`
- Ensure index.html ends with a trailing newline for clean formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3de442848323903cc42edd9154b6